### PR TITLE
feat: add theme selector

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,8 +19,28 @@ const $send = document.getElementById("sendBtn");
 const $clear = document.getElementById("clearBtn");
 const $newSession = document.getElementById("newSessionBtn");
 const $sessionId = document.getElementById("sessionId");
+const $themeRadios = document.querySelectorAll('input[name="theme"]');
 
 $sessionId.textContent = sessionId;
+
+const savedTheme = localStorage.getItem("theme") || "light";
+applyTheme(savedTheme);
+$themeRadios.forEach(radio => {
+  radio.checked = radio.value === savedTheme;
+  radio.addEventListener("change", () => {
+    const choice = radio.value;
+    localStorage.setItem("theme", choice);
+    applyTheme(choice);
+  });
+});
+
+function applyTheme(option) {
+  let theme = option;
+  if (option === "system") {
+    theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  document.documentElement.dataset.theme = theme;
+}
 
 function render() {
   $messages.innerHTML = "";


### PR DESCRIPTION
## Summary
- add theme radio inputs handler and persist selection in localStorage
- apply system theme via matchMedia and set document dataset

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68be97aecb30832e9acd427defc6b643