### PR TITLE
Disable input while loading and prevent concurrent sends

### DIFF
--- a/main.js
+++ b/main.js
@@ -86,6 +86,8 @@ function normalize(t) {
 
 function setLoading(v) {
   loading = v;
+  $send.disabled = v;
+  $input.disabled = v;
   if (v) {
     $typing.classList.remove("hidden");
     startTime = Date.now();
@@ -110,7 +112,13 @@ function setError(msg, canRetry=false) {
 }
 
 // Handlers
-$send.onclick = () => { const t = $input.value.trim(); if (!t) return; $input.value = ""; sendMessage(t); };
+$send.onclick = () => {
+  if (loading) return;
+  const t = $input.value.trim();
+  if (!t) return;
+  $input.value = "";
+  sendMessage(t);
+};
 $input.onkeydown = e => { if (e.key==="Enter" && !e.shiftKey){ e.preventDefault(); $send.click(); } };
 $retry.onclick = () => lastPending && sendMessage(lastPending);
 $clear.onclick = () => { messages=[]; render(); setError(""); };


### PR DESCRIPTION
## Summary
- Disable send button and input field during loading state
- Guard send handler to ignore clicks while loading

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68be97b3e194832e91a8cdf3f548f036