### PR TITLE
Initialize error bar hidden state

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 
       <section id="errorBar" class="error hidden">
         <div id="errorText"></div>
-        <button id="retryBtn" class="btn danger small">Retry</button>
+        <button id="retryBtn" class="btn danger small" style="display:none">Retry</button>
       </section>
 
       <footer class="composer">

--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ const $sessionId = document.getElementById("sessionId");
 const $themeRadios = document.querySelectorAll('input[name="theme"]');
 
 $sessionId.textContent = sessionId;
+setError("");
 
 const savedTheme = localStorage.getItem("theme") || "light";
 applyTheme(savedTheme);


### PR DESCRIPTION
## Summary
- Ensure error bar starts hidden by invoking `setError("")` after DOM initialization
- Hide retry button by default with inline `display:none` style

## Testing
- `node --check main.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be9c389790832e996857a2460a635f