### PR TITLE
Add hidden utility class for toggling elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,6 +32,8 @@ body { margin: 0; background: var(--bg); color: var(--text); font-family: system
 .controls { display: flex; gap: 10px; font-size: 12px; }
 .divider { width: 1px; background: var(--border); }
 
+.hidden { display: none; }
+
 .messages { background: var(--panel); padding: 16px; overflow-y: auto; }
 .row { display: flex; gap: 8px; margin-bottom: 12px; }
 .row.right { justify-content: flex-end; }


### PR DESCRIPTION
## Summary
- add a reusable `.hidden` CSS class to toggle element visibility
- ensure typing indicator and error bar start hidden

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be9c37c734832e9bf39a4512af11bc