### PR TITLE
fix: expand grid rows for session layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,7 +26,7 @@ html[data-theme="dark"] {
 }
 
 body { margin: 0; background: var(--bg); color: var(--text); font-family: system-ui; }
-.app { max-width: 720px; margin: 0 auto; min-height: 100vh; display: grid; grid-template-rows: auto 1fr auto auto auto; }
+.app { max-width: 720px; margin: 0 auto; min-height: 100vh; display: grid; grid-template-rows: auto 1fr auto auto auto auto; }
 .topbar { display: flex; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid var(--border); }
 .brand { font-weight: 600; font-size: 14px; }
 .controls { display: flex; gap: 10px; font-size: 12px; }


### PR DESCRIPTION
## Summary
- extend `.app` grid to six rows so session info has dedicated space

## Testing
- `python3 - <<'PY'
from pathlib import Path
from playwright.sync_api import sync_playwright
file_path = Path('index.html').resolve()
with sync_playwright() as p:
    browser = p.chromium.launch()
    page = browser.new_page()
    page.goto(file_path.as_uri())
    page.evaluate("document.querySelectorAll('.hidden').forEach(el => el.classList.remove('hidden'))")
    selectors = ['.topbar', '#messages', '#typing', '#errorBar', '.composer', '.session']
    boxes = []
    for sel in selectors:
        box = page.locator(sel).bounding_box()
        boxes.append(box)
    browser.close()
for sel, box in zip(selectors, boxes):
    print(sel, box)
for i in range(len(boxes)-1):
    prev = boxes[i]
    nextb = boxes[i+1]
    overlap = not (nextb['y'] >= prev['y'] + prev['height'] - 0.1)
    print(f"{selectors[i]} -> {selectors[i+1]} overlap? {overlap}")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68be9c368848832e9ace8a8f52868d41