### PR TITLE
Ensure typing indicator hidden until chat starts

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 
       <main id="messages" class="messages"></main>
 
-      <section id="typing" class="typing hidden">
+      <section id="typing" class="typing" hidden>
         <div class="row">
           <div class="avatar bot">🤖</div>
           <div class="bubble typing-bubble">
@@ -32,7 +32,7 @@
         </div>
       </section>
 
-      <section id="errorBar" class="error hidden">
+      <section id="errorBar" class="error" hidden>
         <div id="errorText"></div>
         <button id="retryBtn" class="btn danger small" style="display:none">Retry</button>
       </section>

--- a/main.js
+++ b/main.js
@@ -114,7 +114,7 @@ function setLoading(v) {
   $send.disabled = v;
   $input.disabled = v;
   if (v) {
-    $typing.classList.remove("hidden");
+    $typing.hidden = false;
     startTime = Date.now();
     timer = setInterval(() => {
       const ms = Date.now() - startTime;
@@ -123,18 +123,21 @@ function setLoading(v) {
       $elapsed.textContent = mm + ":" + ss;
     }, 1000);
   } else {
-    $typing.classList.add("hidden");
+    $typing.hidden = true;
     clearInterval(timer);
     $elapsed.textContent = "00:00";
   }
-}
+  }
 
-function setError(msg, canRetry=false) {
-  if (!msg) { $errorBar.classList.add("hidden"); return; }
-  $errorText.textContent = msg;
-  $errorBar.classList.remove("hidden");
-  $retry.style.display = canRetry ? "inline-block" : "none";
-}
+  function setError(msg, canRetry=false) {
+    if (!msg) {
+      $errorBar.hidden = true;
+      return;
+    }
+    $errorText.textContent = msg;
+    $errorBar.hidden = false;
+    $retry.style.display = canRetry ? "inline-block" : "none";
+  }
 
 // Handlers
 $send.onclick = () => {

--- a/style.css
+++ b/style.css
@@ -32,8 +32,6 @@ body { margin: 0; background: var(--bg); color: var(--text); font-family: system
 .controls { display: flex; gap: 10px; font-size: 12px; }
 .divider { width: 1px; background: var(--border); }
 
-.hidden { display: none; }
-
 .messages { background: var(--panel); padding: 16px; overflow-y: auto; }
 .row { display: flex; gap: 8px; margin-bottom: 12px; }
 .row.right { justify-content: flex-end; }


### PR DESCRIPTION
## Summary
- Keep typing indicator and error bar hidden by default using the native `hidden` attribute
- Toggle visibility via JavaScript's `hidden` property instead of CSS classes
- Remove unused `.hidden` class from styles

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bea17c1840832e94ff9ccab69d88fa