### PR TITLE
Render and sanitize markdown chat messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
       <div class="session">Session ID: <span id="sessionId"></span></div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -51,10 +51,10 @@ function render() {
     if (m.role === "bot") {
       const av = document.createElement("div"); av.className = "avatar bot"; av.textContent = "🤖"; row.appendChild(av);
     }
-    const wrap = document.createElement("div");
-    const bubble = document.createElement("div");
-    bubble.className = "bubble " + (m.role);
-    bubble.textContent = m.message;
+      const wrap = document.createElement("div");
+      const bubble = document.createElement("div");
+      bubble.className = "bubble " + (m.role);
+      bubble.innerHTML = m.message;
     const meta = document.createElement("div");
     meta.className = "meta"; meta.textContent = new Date(m.ts).toLocaleString();
     wrap.appendChild(bubble); wrap.appendChild(meta); row.appendChild(wrap);
@@ -102,42 +102,14 @@ async function sendMessage(text) {
   }
 }
 
-function normalize(t) {
-  if (!t) return "";
-  let out = t.trim();
-  if ((out.startsWith('"') && out.endsWith('"')) || (out.startsWith("'") && out.endsWith("'"))) out = out.slice(1,-1);
-
-  // Remove basic Markdown syntax
-  out = out
-    // decode links: [text](url) -> text
-    .replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")
-    // bold **text** or __text__ -> text
-    .replace(/\*\*(.*?)\*\*/g, "$1")
-    .replace(/__(.*?)__/g, "$1")
-    // italic *text* or _text_ -> text
-    .replace(/\*(.*?)\*/g, "$1")
-    .replace(/_(.*?)_/g, "$1")
-    // headings # text -> text
-    .replace(/^#{1,6}\s*/gm, "")
-    // bullet markers * or - -> bullet symbol
-    .replace(/^\s*[\*-]\s+/gm, "• ");
-
-  // Convert any HTML markup to readable text
-  const tmp = document.createElement("div");
-  tmp.innerHTML = out;
-  tmp.querySelectorAll("br").forEach(br => br.replaceWith("\n"));
-  tmp.querySelectorAll("p").forEach(p => p.insertAdjacentText("afterend", "\n"));
-  tmp.querySelectorAll("li").forEach(li => {
-    li.insertAdjacentText("beforebegin", "• ");
-    li.insertAdjacentText("afterend", "\n");
-  });
-  out = tmp.textContent || "";
-
-  return out
-    .replace(/\r?\n/g, "\n")      // normalise newlines
-    .replace(/\n{3,}/g, "\n\n")    // collapse excessive spacing
-    .trim();
-}
+  function normalize(t) {
+    if (!t) return "";
+    let out = t.trim();
+    if ((out.startsWith('"') && out.endsWith('"')) || (out.startsWith("'") && out.endsWith("'"))) {
+      out = out.slice(1, -1);
+    }
+    return DOMPurify.sanitize(marked.parse(out));
+  }
 
 function setLoading(v) {
   loading = v;

--- a/style.css
+++ b/style.css
@@ -43,6 +43,10 @@ body { margin: 0; background: var(--bg); color: var(--text); font-family: system
 .bubble.bot { background: var(--bubble-bot); color: var(--bubble-bot-text); border-color: var(--bubble-bot-border); }
 .meta { font-size: 10px; color: var(--muted); margin-top: 4px; }
 
+.bubble table { width: 100%; border-collapse: collapse; }
+.bubble th, .bubble td { border: 1px solid var(--border); padding: 4px 8px; }
+.bubble th { background: var(--panel); font-weight: 600; }
+
 .typing { padding: 0 16px 8px; }
 .dots { display: flex; gap: 4px; }
 .dots span { width: 6px; height: 6px; background: #9ca3af; border-radius: 50%; animation: bounce 1s infinite ease-in-out; }


### PR DESCRIPTION
## Summary
- load marked and DOMPurify to parse markdown and sanitize HTML
- render chat messages with `innerHTML` after parsing/sanitizing to enable tables
- add basic table styling inside chat bubbles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f8dee430832eb7c50322b2015877